### PR TITLE
Remove yard as spec dependency

### DIFF
--- a/polyn_ruby_client/Gemfile.lock
+++ b/polyn_ruby_client/Gemfile.lock
@@ -1,11 +1,10 @@
 PATH
   remote: .
   specs:
-    polyn (0.3.0)
+    polyn (0.3.1)
       json_schemer (~> 0.2)
       nats-pure (~> 2.0)
       opentelemetry-api (~> 1.1)
-      yard (~> 0.9)
 
 GEM
   remote: https://rubygems.org/
@@ -75,9 +74,6 @@ GEM
     timecop (0.9.4)
     unicode-display_width (2.1.0)
     uri_template (0.7.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   arm64-darwin-20

--- a/polyn_ruby_client/lib/polyn/version.rb
+++ b/polyn_ruby_client/lib/polyn/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Polyn
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/polyn_ruby_client/polyn.gemspec
+++ b/polyn_ruby_client/polyn.gemspec
@@ -49,5 +49,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "json_schemer", "~> 0.2"
   spec.add_dependency "nats-pure", "~> 2.0"
   spec.add_dependency "opentelemetry-api", "~> 1.1"
-  spec.add_dependency "yard", "~> 0.9"
 end


### PR DESCRIPTION
The `yard` documentation tool was showing up in application deps which isn't needed