### PR TITLE
POD13-65 polyn migrate task in ci

### DIFF
--- a/polyn_elixir_client/CHANGELOG.md
+++ b/polyn_elixir_client/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.6.1
+
+* Adds Polyn.Release module for working with `mix release`.
+* Requires otp_app config
+
+## 0.6.0
+
+* Adds JetStream migration tooling with `mix polyn.migrate`

--- a/polyn_elixir_client/README.md
+++ b/polyn_elixir_client/README.md
@@ -58,6 +58,14 @@ The [Cloud Event Spec](https://github.com/cloudevents/spec/blob/v1.0.2/cloudeven
 config :polyn, :source_root, "orders.payments"
 ```
 
+### OTP App
+
+Polyn needs to know the name of the otp app that's using it
+
+```elixir
+config :polyn, :otp_app, :my_app
+```
+
 ### NATS Connection
 
 You will need to provide the connection settings for your NATS connection. This will differ in-between environments. More settings options can be seen [here](https://hexdocs.pm/gnat/Gnat.ConnectionSupervisor.html#content)
@@ -109,6 +117,18 @@ Inside the `change` function you can use the functions available in `Polyn.Migra
 ### Tracking Previously Run Migrations
 
 Polyn uses a shared Key-Value bucket in NATS to avoid re-running migrations. It uses the application's `:source_root` as the key to determine which list of run migrations belong to which application.
+
+### Releases
+
+When using `mix release` to deploy, `mix` and Mix Tasks are not available, so you can't use `mix polyn.migrate` to do your migrations.
+
+Instead you can use a built-in `Polyn.Release` module to execute migrations in the compile application
+
+You can use it from the release like this:
+
+```
+_build/prod/rel/my_app/bin/my_app eval "Polyn.Release.migrate"
+```
 
 ## Usage
 

--- a/polyn_elixir_client/README.md
+++ b/polyn_elixir_client/README.md
@@ -122,7 +122,7 @@ Polyn uses a shared Key-Value bucket in NATS to avoid re-running migrations. It 
 
 When using `mix release` to deploy, `mix` and Mix Tasks are not available, so you can't use `mix polyn.migrate` to do your migrations.
 
-Instead you can use a built-in `Polyn.Release` module to execute migrations in the compile application
+Instead you can use a built-in `Polyn.Release` module to execute migrations in the compiled application
 
 You can use it from the release like this:
 

--- a/polyn_elixir_client/config/dev.exs
+++ b/polyn_elixir_client/config/dev.exs
@@ -2,6 +2,7 @@ import Config
 
 config :polyn, :domain, "com.acme"
 config :polyn, :source_root, "user.backend"
+config :polyn, :otp_app, :polyn
 
 config :polyn, :nats, %{
   name: :gnat,

--- a/polyn_elixir_client/config/test.exs
+++ b/polyn_elixir_client/config/test.exs
@@ -2,6 +2,7 @@ import Config
 
 config :polyn, :domain, "com.test"
 config :polyn, :source_root, "user.backend"
+config :polyn, :otp_app, :polyn
 
 config :polyn, :nats, %{
   name: :gnat,

--- a/polyn_elixir_client/lib/mix/tasks/polyn.migrate.ex
+++ b/polyn_elixir_client/lib/mix/tasks/polyn.migrate.ex
@@ -11,8 +11,6 @@ defmodule Mix.Tasks.Polyn.Migrate do
   def run(args) do
     {:ok, _apps} = Application.ensure_all_started(:polyn)
 
-    :ok = Polyn.Connection.wait_for_connection()
-
     parse_args(args)
     |> Migrator.run()
   end

--- a/polyn_elixir_client/lib/polyn/json_store.ex
+++ b/polyn_elixir_client/lib/polyn/json_store.ex
@@ -24,7 +24,7 @@ defmodule Polyn.JSONStore do
 
   ## Examples
 
-      iex>Polyn.Jetstream.KeyValueStore.start_link(connection_name: :gnat)
+      iex>Polyn.Jetstream.JSONStore.start_link(connection_name: :gnat)
       :ok
   """
   @spec start_link(opts :: [option()]) :: GenServer.on_start()

--- a/polyn_elixir_client/lib/polyn/migration/bucket.ex
+++ b/polyn_elixir_client/lib/polyn/migration/bucket.ex
@@ -34,6 +34,9 @@ defmodule Polyn.Migration.Bucket do
         raise Polyn.Migration.Exception,
               "Error looking up already run migrations, #{inspect(reason)}"
 
+      nil ->
+        []
+
       migrations ->
         Jason.decode!(migrations)
     end

--- a/polyn_elixir_client/lib/polyn/migration/migrator.ex
+++ b/polyn_elixir_client/lib/polyn/migration/migrator.ex
@@ -52,7 +52,7 @@ defmodule Polyn.Migration.Migrator do
   Path of migration files
   """
   def migrations_dir do
-    Path.join(File.cwd!(), "/priv/polyn/migrations")
+    Path.join([:code.priv_dir(otp_app()), "polyn", "migrations"])
   end
 
   @doc """
@@ -61,7 +61,7 @@ defmodule Polyn.Migration.Migrator do
   @spec run(opts :: [{:migrations_dir, binary()}]) :: :ok
   @spec run() :: :ok
   def run(opts \\ []) do
-    # The ConnectionSupervisor startup is non-blocking, so we
+    # The Gnat ConnectionSupervisor startup is non-blocking, so we
     # need to make sure the connection to NATS is established
     # before we attempt to migrate
     :ok = Polyn.Connection.wait_for_connection()
@@ -173,5 +173,9 @@ defmodule Polyn.Migration.Migrator do
     end)
 
     state
+  end
+
+  defp otp_app do
+    Application.fetch_env!(:polyn, :otp_app)
   end
 end

--- a/polyn_elixir_client/lib/polyn/migration/migrator.ex
+++ b/polyn_elixir_client/lib/polyn/migration/migrator.ex
@@ -1,7 +1,8 @@
 defmodule Polyn.Migration.Migrator do
-  # Manages the creation and updating of streams and consumers that
-  # an application owns
-  @moduledoc false
+  @moduledoc """
+  Manages the creation and updating of streams and consumers that
+  an application owns
+  """
 
   require Logger
 
@@ -54,6 +55,11 @@ defmodule Polyn.Migration.Migrator do
     Path.join(File.cwd!(), "/priv/polyn/migrations")
   end
 
+  @doc """
+  Entry point for starting migrations
+  """
+  @spec run(opts :: [{:migrations_dir, binary()}]) :: :ok
+  @spec run() :: :ok
   def run(opts \\ []) do
     # The ConnectionSupervisor startup is non-blocking, so we
     # need to make sure the connection to NATS is established

--- a/polyn_elixir_client/lib/polyn/migration/migrator.ex
+++ b/polyn_elixir_client/lib/polyn/migration/migrator.ex
@@ -55,6 +55,11 @@ defmodule Polyn.Migration.Migrator do
   end
 
   def run(opts \\ []) do
+    # The ConnectionSupervisor startup is non-blocking, so we
+    # need to make sure the connection to NATS is established
+    # before we attempt to migrate
+    :ok = Polyn.Connection.wait_for_connection()
+
     new(opts)
     |> get_migration_bucket_info()
     |> create_migration_bucket()

--- a/polyn_elixir_client/lib/polyn/release.ex
+++ b/polyn_elixir_client/lib/polyn/release.ex
@@ -1,11 +1,16 @@
 defmodule Polyn.Release do
   @moduledoc """
-  Utilities for working with Polyn and mix releases
+  Utilities for working with Polyn and mix releases.
   `mix` and mix tasks aren't available in a release. This module
   provides a way to run migrations in a release.
   """
 
   alias Polyn.Migration
+
+  # Using a compile-time env to avoid the chicken-egg problem
+  # of needing the application to be loaded to get the env
+  # to load the application
+  @otp_app Application.compile_env!(:polyn, :otp_app)
 
   @doc """
   Run migrations in a release
@@ -24,11 +29,7 @@ defmodule Polyn.Release do
   end
 
   defp load_app do
-    Application.load(otp_app())
+    Application.load(@otp_app)
     {:ok, _apps} = Application.ensure_all_started(:polyn)
-  end
-
-  defp otp_app do
-    Application.fetch_env!(:polyn, :otp_app)
   end
 end

--- a/polyn_elixir_client/lib/polyn/release.ex
+++ b/polyn_elixir_client/lib/polyn/release.ex
@@ -5,6 +5,8 @@ defmodule Polyn.Release do
   provides a way to run migrations in a release.
   """
 
+  alias Polyn.Migration
+
   @doc """
   Run migrations in a release
 
@@ -18,7 +20,7 @@ defmodule Polyn.Release do
   def migrate do
     load_app()
 
-    Polyn.Migration.Migrator.run()
+    Migration.Migrator.run()
   end
 
   defp load_app do

--- a/polyn_elixir_client/lib/polyn/release.ex
+++ b/polyn_elixir_client/lib/polyn/release.ex
@@ -1,0 +1,32 @@
+defmodule Polyn.Release do
+  @moduledoc """
+  Utilities for working with Polyn and mix releases
+  `mix` and mix tasks aren't available in a release. This module
+  provides a way to run migrations in a release.
+  """
+
+  @doc """
+  Run migrations in a release
+
+  ## Examples
+
+      ```
+      mix release
+      _build/prod/rel/my_app/bin/my_app eval "Polyn.Release.migrate"
+      ```
+  """
+  def migrate do
+    load_app()
+
+    Polyn.Migration.Migrator.run()
+  end
+
+  defp load_app do
+    Application.load(otp_app())
+    {:ok, _apps} = Application.ensure_all_started(:polyn)
+  end
+
+  defp otp_app do
+    Application.fetch_env!(:polyn, :otp_app)
+  end
+end

--- a/polyn_elixir_client/mix.exs
+++ b/polyn_elixir_client/mix.exs
@@ -18,7 +18,7 @@ defmodule Polyn.MixProject do
       name: "Polyn",
       source_url: @github,
       docs: [
-        extras: ["README.md"],
+        extras: ["README.md", "CHANGELOG.md"],
         api_reference: false,
         main: "readme"
       ],

--- a/polyn_elixir_client/mix.exs
+++ b/polyn_elixir_client/mix.exs
@@ -3,7 +3,7 @@ defmodule Polyn.MixProject do
 
   @github "https://github.com/SpiffInc/polyn/tree/main/polyn_elixir_client"
 
-  def version, do: "0.6.0"
+  def version, do: "0.6.1"
 
   def project do
     [

--- a/polyn_elixir_client/test/polyn/migration/bucket_test.exs
+++ b/polyn_elixir_client/test/polyn/migration/bucket_test.exs
@@ -22,11 +22,12 @@ defmodule Polyn.Migration.BucketTest do
     Migration.Bucket.create(@bucket_name)
     Migration.Bucket.add_migration("1234", @bucket_name)
 
-    KV.delete_key(
-      Polyn.Connection.name(),
-      @bucket_name,
-      Application.get_env(:polyn, :source_root)
-    )
+    assert :ok =
+             KV.delete_key(
+               Polyn.Connection.name(),
+               @bucket_name,
+               Application.get_env(:polyn, :source_root)
+             )
 
     assert [] = Migration.Bucket.already_run_migrations(@bucket_name)
   end

--- a/polyn_elixir_client/test/polyn/migration/bucket_test.exs
+++ b/polyn_elixir_client/test/polyn/migration/bucket_test.exs
@@ -23,7 +23,7 @@ defmodule Polyn.Migration.BucketTest do
     Migration.Bucket.add_migration("1234", @bucket_name)
 
     assert :ok =
-             KV.delete_key(
+             KV.purge_key(
                Polyn.Connection.name(),
                @bucket_name,
                Application.get_env(:polyn, :source_root)

--- a/polyn_elixir_client/test/polyn/migration/bucket_test.exs
+++ b/polyn_elixir_client/test/polyn/migration/bucket_test.exs
@@ -1,6 +1,7 @@
 defmodule Polyn.Migration.BucketTest do
   use ExUnit.Case, async: true
 
+  alias Jetstream.API.KV
   alias Polyn.Migration
 
   @bucket_name "BUCKET_TEST"
@@ -21,7 +22,7 @@ defmodule Polyn.Migration.BucketTest do
     Migration.Bucket.create(@bucket_name)
     Migration.Bucket.add_migration("1234", @bucket_name)
 
-    Jetstream.API.KV.delete_key(
+    KV.delete_key(
       Polyn.Connection.name(),
       @bucket_name,
       Application.get_env(:polyn, :source_root)

--- a/polyn_elixir_client/test/polyn/migration/bucket_test.exs
+++ b/polyn_elixir_client/test/polyn/migration/bucket_test.exs
@@ -17,6 +17,19 @@ defmodule Polyn.Migration.BucketTest do
     {:ok, %{"user.backend" => "[\"1234\"]"}} = Migration.Bucket.contents(@bucket_name)
   end
 
+  test "already_run_migrations returns empty list if key deleted" do
+    Migration.Bucket.create(@bucket_name)
+    Migration.Bucket.add_migration("1234", @bucket_name)
+
+    Jetstream.API.KV.delete_key(
+      Polyn.Connection.name(),
+      @bucket_name,
+      Application.get_env(:polyn, :source_root)
+    )
+
+    assert [] = Migration.Bucket.already_run_migrations(@bucket_name)
+  end
+
   test "raises if adding migration when bucket doesn't exist" do
     assert_raise(Polyn.Migration.Exception, fn ->
       Migration.Bucket.add_migration("1234", @bucket_name)


### PR DESCRIPTION
Creates a way to execute polyn migrations inside a deployed mix release. Creates a `Polyn.Release` module that can be accessed from the release. This requires an `:otp_app` configuration now so Polyn can know where to find the `priv` directory with the migrations inside.

Fixes a bug with the migration KV bucket when accessing already run migrations if a key had been deleted
