### PR TITLE
POD13-67 elixir client migration rollbacks

### DIFF
--- a/polyn_elixir_client/CHANGELOG.md
+++ b/polyn_elixir_client/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.3
+
+* Adds `mix polyn.rollback` mix task
+* Adds `up/down` functions for Polyn migrations
+
 ## 0.6.2
 
 * Adds `:max_replicas` config option to allow for replica numbers to differ

--- a/polyn_elixir_client/README.md
+++ b/polyn_elixir_client/README.md
@@ -47,7 +47,7 @@ The [Cloud Event Spec](https://github.com/cloudevents/spec/blob/v1.0.2/cloudeven
 define that domain like this:
 
 ```elixir
-config :polyn, :domain, "app.spiff"
+config :polyn, :domain, "com.my_app"
 ```
 
 ### Message Source Root
@@ -117,6 +117,23 @@ end
 ```
 
 Inside the `change` function you can use the functions available in `Polyn.Migration` to update the NATS server. You can then run `mix polyn.migrate` to apply your changes.
+
+### Rollback
+
+You can rollback a change using `mix polyn.rollback`. Not all `Polyn.Migration` functions can be auto rolled back
+in a `change/0` function. Instead you will have to define `up/down` functions explicitly.
+
+```elixir
+defmodule Polyn.Migrations.UpdateUserStream do
+  import Polyn.Migration
+
+  def up do
+  end
+
+  def down do
+  end
+end
+```
 
 ### Tracking Previously Run Migrations
 

--- a/polyn_elixir_client/lib/mix/tasks/polyn.rollback.ex
+++ b/polyn_elixir_client/lib/mix/tasks/polyn.rollback.ex
@@ -1,0 +1,26 @@
+defmodule Mix.Tasks.Polyn.Rollback do
+  @moduledoc """
+  Use `mix polyn.rollback` to rollback a change to your NATS server.
+  """
+  @shortdoc "Rolls back a migration to your NATS Server"
+
+  use Mix.Task
+
+  alias Polyn.Migration.Migrator
+
+  def run(args) do
+    {:ok, _apps} = Application.ensure_all_started(:polyn)
+
+    parse_args(args)
+    |> Keyword.put(:direction, :down)
+    |> Migrator.run()
+  end
+
+  defp parse_args(args) do
+    {options, []} = OptionParser.parse!(args, strict: [migrations_dir: :string])
+
+    [
+      migrations_dir: Keyword.get(options, :migrations_dir, Migrator.migrations_dir())
+    ]
+  end
+end

--- a/polyn_elixir_client/lib/polyn/migration/bucket.ex
+++ b/polyn_elixir_client/lib/polyn/migration/bucket.ex
@@ -52,6 +52,15 @@ defmodule Polyn.Migration.Bucket do
     KV.put_value(Connection.name(), bucket_name, bucket_key(), migrations)
   end
 
+  def remove_migration(migration_id, bucket_name \\ @bucket_name) do
+    migrations =
+      already_run_migrations(bucket_name)
+      |> Enum.reject(&(&1 == migration_id))
+      |> Jason.encode!()
+
+    KV.put_value(Connection.name(), bucket_name, bucket_key(), migrations)
+  end
+
   defp bucket_key do
     # We're using the `source_root` as the namespace/key for all the migrations
     # for the application using Polyn. We're assuming only one application owns the

--- a/polyn_elixir_client/lib/polyn/migration/bucket.ex
+++ b/polyn_elixir_client/lib/polyn/migration/bucket.ex
@@ -44,7 +44,10 @@ defmodule Polyn.Migration.Bucket do
 
   def add_migration(migration_id, bucket_name \\ @bucket_name) do
     migrations =
-      already_run_migrations(bucket_name) |> Enum.concat([migration_id]) |> Jason.encode!()
+      already_run_migrations(bucket_name)
+      |> Enum.concat([migration_id])
+      |> Enum.sort()
+      |> Jason.encode!()
 
     KV.put_value(Connection.name(), bucket_name, bucket_key(), migrations)
   end

--- a/polyn_elixir_client/lib/polyn/migration/command.ex
+++ b/polyn_elixir_client/lib/polyn/migration/command.ex
@@ -7,7 +7,7 @@ defmodule Polyn.Migration.Command do
   alias Polyn.Migration
 
   @doc "Actually apply the change to the server"
-  def execute({id, :create_stream, opts}, migrator_state) do
+  def execute(id, {:create_stream, opts}, migrator_state) do
     opts = maybe_limit_replicas(opts)
     stream = struct(Stream, opts)
 
@@ -15,7 +15,7 @@ defmodule Polyn.Migration.Command do
     |> handle_execute_result(id, migrator_state)
   end
 
-  def execute({id, :update_stream, opts}, migrator_state) do
+  def execute(id, {:update_stream, opts}, migrator_state) do
     opts = maybe_limit_replicas(opts)
     stream = update_stream_config(opts)
 
@@ -23,19 +23,19 @@ defmodule Polyn.Migration.Command do
     |> handle_execute_result(id, migrator_state)
   end
 
-  def execute({id, :delete_stream, stream_name}, migrator_state) do
+  def execute(id, {:delete_stream, stream_name}, migrator_state) do
     Stream.delete(Connection.name(), stream_name)
     |> handle_execute_result(id, migrator_state)
   end
 
-  def execute({id, :create_consumer, opts}, migrator_state) do
+  def execute(id, {:create_consumer, opts}, migrator_state) do
     consumer = struct(Consumer, opts)
 
     Consumer.create(Connection.name(), consumer)
     |> handle_execute_result(id, migrator_state)
   end
 
-  def execute({id, :delete_consumer, opts}, migrator_state) do
+  def execute(id, {:delete_consumer, opts}, migrator_state) do
     stream_name = Keyword.get(opts, :stream_name)
     durable_name = Keyword.get(opts, :durable_name)
 

--- a/polyn_elixir_client/lib/polyn/migration/migrator.ex
+++ b/polyn_elixir_client/lib/polyn/migration/migrator.ex
@@ -16,6 +16,7 @@ defmodule Polyn.Migration.Migrator do
 
   @typedoc """
   * `:direction` - Which direction to migrate
+  * `:migrations_function` - The function to run inside the migration module (e.g. `change`, `up`, `down`)
   * `:migrations_dir` - Location of migration files
   * `:running_migration_id` - The timestamp/id of the migration file being run. Taken from the beginning of the file name
   * `:migration_bucket_info` - The Stream info for the migration KV bucket
@@ -27,6 +28,7 @@ defmodule Polyn.Migration.Migrator do
   """
   @type t :: %__MODULE__{
           direction: :up | :down,
+          migration_function: :change | :up | :down,
           migrations_dir: binary(),
           running_migration_id: non_neg_integer() | nil,
           migration_bucket_info: Jetstream.API.Stream.info() | nil,
@@ -40,6 +42,7 @@ defmodule Polyn.Migration.Migrator do
   # Holds the state of the migration as we move through migration steps
   defstruct [
     :direction,
+    :migration_function,
     :running_migration_id,
     :migrations_dir,
     :migration_bucket_info,
@@ -186,12 +189,28 @@ defmodule Polyn.Migration.Migrator do
 
     Enum.each(state.migration_modules, fn {id, module} ->
       Runner.update_running_migration_id(pid, id)
-      module.change()
+      func = migration_function(module, state)
+      Runnner.update_migration_function(pid, func)
+      apply(module, func, [])
     end)
 
     state = Runner.get_state(pid) |> Map.put(:running_migration_id, nil)
     Runner.stop(pid)
     state
+  end
+
+  defp migration_function(module, %{direction: direction}) do
+    cond do
+      function_exported?(module, direction, 0) ->
+        direction
+
+      function_exported?(module, :change, 0) ->
+        :change
+
+      true ->
+        raise Polyn.Migration.Exception,
+              "Migration module #{module} does not define a #{inspect(direction)}/0 or change/0 function"
+    end
   end
 
   defp execute_commands(%{commands: commands} = state) do

--- a/polyn_elixir_client/lib/polyn/migration/migrator.ex
+++ b/polyn_elixir_client/lib/polyn/migration/migrator.ex
@@ -10,6 +10,12 @@ defmodule Polyn.Migration.Migrator do
   alias Polyn.Migration.Runner
 
   @typedoc """
+  Tuple of {migration_id, command_name, command_options}
+  """
+  @type command :: {integer(), atom(), any()}
+
+  @typedoc """
+  * `:direction` - Which direction to migrate
   * `:migrations_dir` - Location of migration files
   * `:running_migration_id` - The timestamp/id of the migration file being run. Taken from the beginning of the file name
   * `:migration_bucket_info` - The Stream info for the migration KV bucket
@@ -17,16 +23,17 @@ defmodule Polyn.Migration.Migrator do
   * `:migration_files` - The file names of migration files
   * `:migration_modules` - A list of tuples with the migration id and module code
   * `:already_run_migrations` - Migrations we've determined have already been executed on the server
-  * `:commands` - list of tuples with {migration_id, command_name, command_options}
+  * `:commands` - list of command tuples with
   """
   @type t :: %__MODULE__{
+          direction: :up | :down,
           migrations_dir: binary(),
           running_migration_id: non_neg_integer() | nil,
           migration_bucket_info: Jetstream.API.Stream.info() | nil,
           runner: pid() | nil,
           migration_files: [binary()],
           migration_modules: [{integer(), module()}],
-          commands: [{integer(), atom(), any()}],
+          commands: [command()],
           already_run_migrations: [binary()]
         }
 

--- a/polyn_elixir_client/lib/polyn/migration/runner.ex
+++ b/polyn_elixir_client/lib/polyn/migration/runner.ex
@@ -34,7 +34,7 @@ defmodule Polyn.Migration.Runner do
     {migration_id, command_name, opts}
   end
 
-  defp build_command(state, migration_id, command_name, opts) do
+  defp build_command(_state, migration_id, command_name, opts) do
     {migration_id, command_name, opts}
   end
 
@@ -55,5 +55,9 @@ defmodule Polyn.Migration.Runner do
 
   defp reverse(:create_stream, opts) do
     {:delete_stream, Keyword.get(opts, :name)}
+  end
+
+  defp reverse(:create_consumer, opts) do
+    {:delete_consumer, Keyword.take(opts, [:durable_name, :stream_name])}
   end
 end

--- a/polyn_elixir_client/lib/polyn/migration/runner.ex
+++ b/polyn_elixir_client/lib/polyn/migration/runner.ex
@@ -32,7 +32,12 @@ defmodule Polyn.Migration.Runner do
     end
   end
 
-  defp build_command(%{direction: :down} = state, migration_id, command_name, opts) do
+  defp build_command(
+         %{direction: :down, migration_function: :change} = state,
+         migration_id,
+         command_name,
+         opts
+       ) do
     case reverse(command_name, opts) do
       {command_name, opts} ->
         {:ok, {migration_id, command_name, opts}}
@@ -62,6 +67,13 @@ defmodule Polyn.Migration.Runner do
   def update_running_migration_id(pid, id) do
     Agent.update(pid, fn state ->
       Map.put(state, :running_migration_id, id)
+    end)
+  end
+
+  @doc "Update the state to know which migration function is being executed based on direction"
+  def update_migration_function(pid, func) do
+    Agent.update(pid, fn state ->
+      Map.put(state, :migration_function, func)
     end)
   end
 

--- a/polyn_elixir_client/mix.exs
+++ b/polyn_elixir_client/mix.exs
@@ -3,7 +3,7 @@ defmodule Polyn.MixProject do
 
   @github "https://github.com/SpiffInc/polyn/tree/main/polyn_elixir_client"
 
-  def version, do: "0.6.2"
+  def version, do: "0.6.3"
 
   def project do
     [

--- a/polyn_elixir_client/test/polyn/migration/bucket_test.exs
+++ b/polyn_elixir_client/test/polyn/migration/bucket_test.exs
@@ -32,8 +32,8 @@ defmodule Polyn.Migration.BucketTest do
     assert [] = Migration.Bucket.already_run_migrations(@bucket_name)
   end
 
-  # This could happen if one engineer creates a migration after another engineer,
-  # but get's their migration merged first.
+  # This could happen if engineer A creates a migration at a later time than
+  # engineer B, but engineer A gets their migration merged first.
   test "puts migrations in order if existing migration has later timestamp" do
     Migration.Bucket.create(@bucket_name)
     Migration.Bucket.add_migration("5555", @bucket_name)

--- a/polyn_elixir_client/test/polyn/migration/bucket_test.exs
+++ b/polyn_elixir_client/test/polyn/migration/bucket_test.exs
@@ -37,9 +37,7 @@ defmodule Polyn.Migration.BucketTest do
   test "puts migrations in order if existing migration has later timestamp" do
     Migration.Bucket.create(@bucket_name)
     Migration.Bucket.add_migration("5555", @bucket_name)
-    :timer.sleep(100)
     Migration.Bucket.add_migration("1234", @bucket_name)
-    :timer.sleep(100)
 
     assert {:ok, %{"user.backend" => "[\"1234\",\"5555\"]"}} =
              Migration.Bucket.contents(@bucket_name)
@@ -49,8 +47,6 @@ defmodule Polyn.Migration.BucketTest do
     Migration.Bucket.create(@bucket_name)
     Migration.Bucket.add_migration("1234", @bucket_name)
     Migration.Bucket.add_migration("5555", @bucket_name)
-
-    :timer.sleep(100)
 
     assert {:ok, %{"user.backend" => "[\"1234\",\"5555\"]"}} =
              Migration.Bucket.contents(@bucket_name)

--- a/polyn_elixir_client/test/polyn/migration/bucket_test.exs
+++ b/polyn_elixir_client/test/polyn/migration/bucket_test.exs
@@ -45,6 +45,21 @@ defmodule Polyn.Migration.BucketTest do
              Migration.Bucket.contents(@bucket_name)
   end
 
+  test "removes a migration" do
+    Migration.Bucket.create(@bucket_name)
+    Migration.Bucket.add_migration("1234", @bucket_name)
+    Migration.Bucket.add_migration("5555", @bucket_name)
+
+    :timer.sleep(100)
+
+    assert {:ok, %{"user.backend" => "[\"1234\",\"5555\"]"}} =
+             Migration.Bucket.contents(@bucket_name)
+
+    assert :ok = Migration.Bucket.remove_migration("1234", @bucket_name)
+
+    assert {:ok, %{"user.backend" => "[\"5555\"]"}} = Migration.Bucket.contents(@bucket_name)
+  end
+
   test "raises if adding migration when bucket doesn't exist" do
     assert_raise(Polyn.Migration.Exception, fn ->
       Migration.Bucket.add_migration("1234", @bucket_name)

--- a/polyn_elixir_client/test/polyn/migration/migrator_test.exs
+++ b/polyn_elixir_client/test/polyn/migration/migrator_test.exs
@@ -98,8 +98,6 @@ defmodule Polyn.Migration.MigratorTest do
 
       run(context)
 
-      :timer.sleep(100)
-
       assert ["1234"] == Migration.Bucket.already_run_migrations()
       Jetstream.API.Stream.delete(Connection.name(), "other_stream")
     end


### PR DESCRIPTION
Adds a `mix polyn.rollback` task for local dev. Allows for `up/down` functions in migrations