### PR TITLE
Dialyzer not able to read beam files

### DIFF
--- a/polyn_elixir_client/CHANGELOG.md
+++ b/polyn_elixir_client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.5
+
+* Fix bug where dialyzer couldn't find metadata, because `:debug_info` was turned off.
+
 ## 0.6.4
 
 * Change from `uuid` lib to `elixir_uuid` lib.

--- a/polyn_elixir_client/mix.exs
+++ b/polyn_elixir_client/mix.exs
@@ -11,8 +11,6 @@ defmodule Polyn.MixProject do
       version: version(),
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
-      elixirc_options: [debug_info: Mix.env() == :dev],
-      start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),
       name: "Polyn",

--- a/polyn_elixir_client/mix.exs
+++ b/polyn_elixir_client/mix.exs
@@ -3,7 +3,7 @@ defmodule Polyn.MixProject do
 
   @github "https://github.com/SpiffInc/polyn/tree/main/polyn_elixir_client"
 
-  def version, do: "0.6.4"
+  def version, do: "0.6.5"
 
   def project do
     [

--- a/polyn_elixir_client/mix.exs
+++ b/polyn_elixir_client/mix.exs
@@ -42,7 +42,7 @@ defmodule Polyn.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger],
+      extra_applications: [:logger, :eex],
       mod: {Polyn.Application, []}
     ]
   end

--- a/polyn_elixir_client/mix.lock
+++ b/polyn_elixir_client/mix.lock
@@ -26,5 +26,4 @@
   "opentelemetry_api": {:hex, :opentelemetry_api, "1.1.0", "156366bfbf249f54daf2626e087e29ad91201eab670993fd9ae1bd278d03a096", [:mix, :rebar3], [], "hexpm", "e0d0b49e21e5785da675c97104c385283cae84fcc0d8522932a5dcf55489ead1"},
   "polyn_naming": {:hex, :polyn_naming, "0.2.0", "6db9d12774f08d8ff6fd111a838ccfee8e6ae99eb9532f6bf823772c0b4f1aa7", [:mix], [], "hexpm", "e6911b8acd76143afcb20d742316bbf36bd0ded3770a6ea50441523db813a205"},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
-  "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm", "c790593b4c3b601f5dc2378baae7efaf5b3d73c4c6456ba85759905be792f2ac"},
 }


### PR DESCRIPTION
Fix a bug where dialyzer couldn't see beam files for Polyn when used as a dependency in a project. See [Elixir Forum discussion](https://elixirforum.com/t/dialyzer-could-not-get-core-erlang-code-for/56730/11)